### PR TITLE
Feature/#111-tossPaymentService-service-controller

### DIFF
--- a/Backend/spring-boot-library/.gitignore
+++ b/Backend/spring-boot-library/.gitignore
@@ -6,12 +6,16 @@
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 application.properties
 .DS_Store
+TossPaymentConfig.java
 # User-specific stuff
+
 .idea/**/workspace.xml
 .idea/**/tasks.xml
 .idea/**/usage.statistics.xml
 .idea/**/dictionaries
 .idea/**/shelf
+.idea/**/google**
+.idea/inspectionProfiles/Project_Default.xml
 .gitignore
 # AWS User-specific
 .idea/**/aws.xml

--- a/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/Controller/PaymentController.java
+++ b/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/Controller/PaymentController.java
@@ -1,24 +1,18 @@
 package com.reactlibraryproject.springbootlibrary.Controller;
 
 import com.reactlibraryproject.springbootlibrary.ReponseModels.PaymentHistoryResponse;
-import com.reactlibraryproject.springbootlibrary.RequestModels.AddPaymentRequest;
+import com.reactlibraryproject.springbootlibrary.RequestModels.PendingPaymentRequest;
 import com.reactlibraryproject.springbootlibrary.RequestModels.SuccessPaymentRequest;
 import com.reactlibraryproject.springbootlibrary.Service.PaymentService;
 import com.reactlibraryproject.springbootlibrary.Utils.ExtractJWT;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @CrossOrigin("https://localhost:3000")
 @RestController
@@ -30,38 +24,36 @@ public class PaymentController {
   private PaymentService paymentService;
 
   @Operation(summary = "결제 내역 조회")
-  @GetMapping("/secure/histories")
-  public List<PaymentHistoryResponse> purchaseHistories(
-      @RequestHeader(value = "Authorization") String token) throws Exception {
+  @GetMapping("/secure/history")
+  public Map<String, List<PaymentHistoryResponse>> paymentHistoryResponses(
+      @RequestHeader(value = "Authorization") String token) {
     String userEmail = ExtractJWT.payloadJWTExtraction(token, "\"sub\"");
-    return paymentService.paymentHistories(userEmail);
+    return paymentService.paymentHistoryResponses(userEmail);
   }
 
   @Operation(summary = "결제 승인 전 DB에 추가")
   @PostMapping("/secure")
-  public void addPendingPurchases(
+  public void addPendingPayments(
       @RequestHeader(value = "Authorization") String token,
-      @RequestBody List<AddPaymentRequest> paymentRequests)
-      throws Exception {
+      @RequestBody List<PendingPaymentRequest> paymentRequests) {
     String userEmail = ExtractJWT.payloadJWTExtraction(token, "\"sub\"");
     paymentService.addPendingPayments(userEmail, paymentRequests);
   }
 
-  @Operation(summary = "결제 승인 전 오류시 DB에서 삭제")
+  @Operation(summary = "결제 실패시 DB에서 삭제")
   @DeleteMapping("/secure/delete/fail")
-  public void deleteFailPurchase(@RequestHeader(value = "Authorization") String token)
-      throws Exception {
+  public void failPayment(@RequestHeader(value = "Authorization") String token) throws Exception {
     String userEmail = ExtractJWT.payloadJWTExtraction(token, "\"sub\"");
-    paymentService.deleteFailPayment(userEmail);
+    paymentService.failPayment(userEmail);
   }
 
   @Operation(summary = "결제 승인 API 호출", description = "API 호출 후 결제 내역 업데이트")
-  @PutMapping("/secure/update")
-  public void updateSuccessPayment(
+  @PostMapping("/secure/confirm")
+  public ResponseEntity<String> successPayment(
       @RequestHeader(value = "Authorization") String token,
       @RequestBody SuccessPaymentRequest paymentRequests)
       throws Exception {
     String userEmail = ExtractJWT.payloadJWTExtraction(token, "\"sub\"");
-    paymentService.updateSuccessPayment(userEmail, paymentRequests);
+    return paymentService.successPayment(userEmail, paymentRequests);
   }
 }


### PR DESCRIPTION
1. `PaymentService`
 - `paymentHistoryResponses()` : 사용자의 결제 내역을 조회하고 일별로 그룹화하여 반환합니다. successPayment(): 결제 요청을 처리하고 Toss Payments API를 호출하여 결제 승인을 진행합니다. 결제가 성공하면 결제 내역을 업데이트하고, 실패하면 결제 내역을 삭제합니다. - `failPayment()` : 결제 실패 시 사용자의 결제 내역을 삭제합니다.
- `addPendingPayments()` : 결제 승인 전에 사용자의 결제 내역을 DB에 저장합니다. updatePayments(): 결제 내역을 업데이트하고 카트 항목을 삭제합니다.

2. `PaymentController`
- `paymentHistoryResponses()` : 사용자의 결제 내역을 조회하는 엔드포인트입니다.
- `addPendingPayments()` : 결제 승인 전에 사용자의 결제 내역을 DB에 추가하는 엔드포인트입니다.
- `failPayment()` : 결제 실패 시 사용자의 결제 내역을 삭제하는 엔드포인트입니다.
- `successPayment()` : 결제 승인을 처리하는 엔드포인트입니다. Toss Payments API를 호출하여 결제 승인을 진행하고, 결제 내역을 업데이트합니다.

tossSecretKey가 담긴 tossConfig.java를 깃 이그노어에 추가함.