### PR TITLE
refactor/#106-MessageService-Exception

### DIFF
--- a/src/main/java/com/reactlibraryproject/springbootlibrary/CustomExceptions/MessageNotFoundException.java
+++ b/src/main/java/com/reactlibraryproject/springbootlibrary/CustomExceptions/MessageNotFoundException.java
@@ -1,0 +1,7 @@
+package com.reactlibraryproject.springbootlibrary.CustomExceptions;
+
+public class MessageNotFoundException extends RuntimeException{
+    public MessageNotFoundException() {
+        super("메세지를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/com/reactlibraryproject/springbootlibrary/Service/MessageService.java
+++ b/src/main/java/com/reactlibraryproject/springbootlibrary/Service/MessageService.java
@@ -1,5 +1,6 @@
 package com.reactlibraryproject.springbootlibrary.Service;
 
+import com.reactlibraryproject.springbootlibrary.CustomExceptions.MessageNotFoundException;
 import com.reactlibraryproject.springbootlibrary.DAO.MessageRepository;
 import com.reactlibraryproject.springbootlibrary.Entity.Message;
 import com.reactlibraryproject.springbootlibrary.RequestModels.AdminQuestionRequest;
@@ -25,10 +26,10 @@ public class MessageService {
         messageRepository.save(message);
     }
 
-    public void putMessage(AdminQuestionRequest adminQuestionRequest, String adminEmail) throws Exception {
+    public void putMessage(AdminQuestionRequest adminQuestionRequest, String adminEmail) {
         Optional<Message> foundMessage = messageRepository.findById(adminQuestionRequest.getId());
         if (foundMessage.isEmpty()) {
-            throw new Exception("Message not found");
+            throw new MessageNotFoundException();
         }
         Message message = Message.builder()
          .id(foundMessage.get().getId())

--- a/src/test/java/com/reactlibraryproject/springbootlibrary/Service/MessageServiceTest.java
+++ b/src/test/java/com/reactlibraryproject/springbootlibrary/Service/MessageServiceTest.java
@@ -17,8 +17,8 @@ import org.mockito.quality.Strictness;
 import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("문의게시판 테스트")
@@ -38,7 +38,7 @@ class MessageServiceTest {
   void setUp() {
     userEmail = "user@email.com";
     message =
-        Message.builder().id(1L).userEmail(userEmail).title("Title").question("question").build();
+        Message.builder().userEmail(userEmail).title("Title").question("question").build();
   }
 
   @Test
@@ -55,13 +55,13 @@ class MessageServiceTest {
 
   @Test
   @DisplayName("관리자 - 응답하기")
-  void putMessage() throws Exception {
+  void putMessage() {
     // Given
     String adminEmail = "admin@email.com";
     String response = "response";
     AdminQuestionRequest adminQuestionRequest = new AdminQuestionRequest(1L, response);
-    given(messageRepository.findById(adminQuestionRequest.getId()))
-        .willReturn(Optional.of(message));
+    when(messageRepository.findById(adminQuestionRequest.getId()))
+        .thenReturn(Optional.of(message));
 
     // When
     messageService.putMessage(adminQuestionRequest, adminEmail);


### PR DESCRIPTION
`MessageNotFoundException` - 메세지를 찾을 수 없을 때 발생하는 사용자 정의 예외처리 클래스를 생성하고, 테스트 코드를 수정했다.