### PR TITLE
Refactor/payment service refactor

### DIFF
--- a/src/main/java/com/reactlibraryproject/springbootlibrary/Controller/PaymentHistoryController.java
+++ b/src/main/java/com/reactlibraryproject/springbootlibrary/Controller/PaymentHistoryController.java
@@ -9,7 +9,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 import java.util.Map;
@@ -21,39 +28,38 @@ import java.util.Map;
 @Tag(name = "결제", description = "결제 API")
 public class PaymentHistoryController {
 
-  private PaymentService paymentService;
+    private PaymentService paymentService;
 
-  @Operation(summary = "결제 내역 조회")
-  @GetMapping("/secure")
-  public Map<String, List<PaymentHistoryResponse>> paymentHistoryResponses(
-      @RequestHeader(value = "Authorization") String token) {
-    String userEmail = ExtractJWT.payloadJWTExtraction(token, "\"sub\"");
-    return paymentService.paymentHistoryResponses(userEmail);
-  }
+    @Operation(summary = "결제 내역 조회")
+    @GetMapping("/secure")
+    public Map<String, List<PaymentHistoryResponse>> paymentHistoryResponses(
+     @RequestHeader(value = "Authorization") String token) {
+        String userEmail = ExtractJWT.payloadJWTExtraction(token, "\"sub\"");
+        return paymentService.paymentHistoryResponses(userEmail);
+    }
 
-  @Operation(summary = "결제 승인 전 DB에 추가")
-  @PostMapping("/secure/addpending")
-  public void addPendingPayments(
-      @RequestHeader(value = "Authorization") String token,
-      @RequestBody List<PendingPaymentRequest> paymentRequests) {
-    String userEmail = ExtractJWT.payloadJWTExtraction(token, "\"sub\"");
-    paymentService.addPendingPayments(userEmail, paymentRequests);
-  }
+    @Operation(summary = "결제 승인 전 DB에 추가")
+    @PostMapping("/secure/addpending")
+    public void addPendingPayments(
+     @RequestHeader(value = "Authorization") String token,
+     @RequestBody List<PendingPaymentRequest> paymentRequests) {
+        String userEmail = ExtractJWT.payloadJWTExtraction(token, "\"sub\"");
+        paymentService.addPendingPayments(userEmail, paymentRequests);
+    }
 
-  @Operation(summary = "결제 실패시 DB에서 삭제")
-  @DeleteMapping("/secure/delete/fail")
-  public void failPayment(@RequestHeader(value = "Authorization") String token) throws Exception {
-    String userEmail = ExtractJWT.payloadJWTExtraction(token, "\"sub\"");
-    paymentService.failPayment(userEmail);
-  }
+    @Operation(summary = "결제 실패시 DB에서 삭제")
+    @DeleteMapping("/secure/delete/fail")
+    public void deleteFailPayment(@RequestHeader(value = "Authorization") String token) {
+        String userEmail = ExtractJWT.payloadJWTExtraction(token, "\"sub\"");
+        paymentService.deleteFailPayment(userEmail);
+    }
 
-  @Operation(summary = "결제 승인 API 호출", description = "API 호출 후 결제 내역 업데이트")
-  @PostMapping("/secure/confirm")
-  public ResponseEntity<String> successPayment(
-      @RequestHeader(value = "Authorization") String token,
-      @RequestBody SuccessPaymentRequest paymentRequests)
-      throws Exception {
-    String userEmail = ExtractJWT.payloadJWTExtraction(token, "\"sub\"");
-    return paymentService.successPayment(userEmail, paymentRequests);
-  }
+    @Operation(summary = "결제 승인 API 호출", description = "API 호출 후 결제 내역 업데이트")
+    @PostMapping("/secure/confirm")
+    public ResponseEntity<String> confirmPayment(
+     @RequestHeader(value = "Authorization") String token,
+     @RequestBody SuccessPaymentRequest paymentRequests){
+        String userEmail = ExtractJWT.payloadJWTExtraction(token, "\"sub\"");
+        return paymentService.confirmPayment(userEmail, paymentRequests);
+    }
 }

--- a/src/main/java/com/reactlibraryproject/springbootlibrary/CustomExceptions/TossPayResponseException.java
+++ b/src/main/java/com/reactlibraryproject/springbootlibrary/CustomExceptions/TossPayResponseException.java
@@ -3,17 +3,16 @@ package com.reactlibraryproject.springbootlibrary.CustomExceptions;
 import org.json.JSONObject;
 import org.springframework.http.ResponseEntity;
 
-import java.net.http.HttpResponse;
-
 public class TossPayResponseException extends RuntimeException {
 
-  public TossPayResponseException(ResponseEntity<String> response) {
-    super(getException(response));
-  }
-  private static String getException(ResponseEntity<String> response) {
-    JSONObject jsonObject = new JSONObject(response.getBody());
-    String code = jsonObject.getString("code");
-    String message = jsonObject.getString("message");
-    return response.getStatusCode() + " - " + code + ": " + message;
-  }
+    public TossPayResponseException(ResponseEntity<String> response) {
+        super(getException(response));
+    }
+
+    private static String getException(ResponseEntity<String> response) {
+        JSONObject jsonObject = new JSONObject(response.getBody());
+        String code = jsonObject.getString("code");
+        String message = jsonObject.getString("message");
+        return response.getStatusCode() + " - " + code + ": " + message;
+    }
 }

--- a/src/main/java/com/reactlibraryproject/springbootlibrary/ReponseModels/PaymentHistoryResponse.java
+++ b/src/main/java/com/reactlibraryproject/springbootlibrary/ReponseModels/PaymentHistoryResponse.java
@@ -7,6 +7,8 @@ import lombok.Data;
 @AllArgsConstructor
 public class PaymentHistoryResponse {
 
+  private Long id;
+
   private String title;
 
   private String author;

--- a/src/main/java/com/reactlibraryproject/springbootlibrary/Service/PaymentService.java
+++ b/src/main/java/com/reactlibraryproject/springbootlibrary/Service/PaymentService.java
@@ -16,8 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.io.IOException;
-import java.net.http.HttpResponse;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -27,98 +26,98 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 public class PaymentService {
 
-  private PaymentHistoryRepository paymentHistoryRepository;
-  private CartItemService cartItemService;
-  private BookFinder bookFinder;
+    private PaymentHistoryRepository paymentHistoryRepository;
+    private CartItemService cartItemService;
+    private BookFinder bookFinder;
 
-  public Map<String, List<PaymentHistoryResponse>> paymentHistoryResponses(String userEmail) {
-    List<PaymentHistory> paymentHistories =
-        paymentHistoryRepository.findPaymentByUserEmail(userEmail);
+    public Map<String, List<PaymentHistoryResponse>> paymentHistoryResponses(String userEmail) {
+        deleteFailPayment(userEmail);
+        List<PaymentHistory> paymentHistories =
+         paymentHistoryRepository.findPaymentByUserEmail(userEmail);
+        paymentHistories.sort(Comparator.comparing(PaymentHistory::getPaymentDate).reversed());
 
-    return paymentHistories.stream()
-        .map(
-            paymentHistory ->
-                new PaymentHistoryResponse(
-                    paymentHistory.getTitle(),
-                    paymentHistory.getAuthor(),
-                    paymentHistory.getCategory(),
-                    paymentHistory.getImg(),
-                    paymentHistory.getPublisher(),
-                    paymentHistory.getAmount(),
-                    paymentHistory.getPrice(),
-                    paymentHistory.getPaymentDate(),
-                    paymentHistory.getOrderId()))
-        .collect(Collectors.groupingBy(PaymentHistoryResponse::getPaymentDate));
-  }
-
-  public ResponseEntity<String> successPayment(
-      String userEmail, SuccessPaymentRequest paymentRequests)
-      throws IOException, InterruptedException {
-    ResponseEntity<String> response = TossPay.pay(paymentRequests);
-    if (response.getStatusCodeValue() == 200) {
-        updatePayments(userEmail, response);
-    } else {
-        failPayment(userEmail);
-        throw new TossPayResponseException(response);
+        return paymentHistories.stream()
+         .map(
+          paymentHistory ->
+           new PaymentHistoryResponse(
+            paymentHistory.getId(),
+            paymentHistory.getTitle(),
+            paymentHistory.getAuthor(),
+            paymentHistory.getCategory(),
+            paymentHistory.getImg(),
+            paymentHistory.getPublisher(),
+            paymentHistory.getAmount(),
+            paymentHistory.getPrice(),
+            paymentHistory.getPaymentDate(),
+            paymentHistory.getOrderId()))
+         .collect(Collectors.groupingBy(PaymentHistoryResponse::getOrderId));
     }
-    return response;
-  }
 
-  public void failPayment(String userEmail) {
-    paymentHistoryRepository.deleteByUserEmailAndStatusIsNull(userEmail);
-  }
-
-  public void addPendingPayments(String userEmail, List<PendingPaymentRequest> paymentRequests) {
-    paymentRequests.forEach(
-        paymentRequest -> {
-          Book book = bookFinder.bookFinder(paymentRequest.getBookId());
-          addPendingPayment(userEmail, book, paymentRequest);
-        });
-  }
-
-  private void addPendingPayment(
-      String userEmail, Book book, PendingPaymentRequest paymentRequest) {
-    PaymentHistory paymentHistory =
-        PaymentHistory.builder()
-            .userEmail(userEmail)
-            .title(book.getTitle())
-            .author(book.getAuthor())
-            .category(book.getCategory())
-            .img(book.getImg())
-            .publisher(book.getPublisher())
-            .amount(paymentRequest.getAmount())
-            .price(paymentRequest.getAmount() * book.getPrice())
-            .cartItemId(paymentRequest.getCartItemId())
-            .build();
-    paymentHistoryRepository.save(paymentHistory);
-  }
-
-  private void updatePayments(String userEmail, ResponseEntity<String> response) {
-    JSONObject jsonObject = new JSONObject(response.getBody());
-    String paymentKey = jsonObject.getString("paymentKey");
-    String orderId = jsonObject.getString("orderId");
-    String paymentDate = jsonObject.getString("approvedAt");
-    String status = jsonObject.getString("status");
-
-    List<PaymentHistory> pendingPaymentHistories =
-        paymentHistoryRepository.findByUserEmailAndStatusIsNull(userEmail);
-
-    int responseTotalPrice = jsonObject.getInt("totalAmount");
-    int getTotalPrice = pendingPaymentHistories.stream().mapToInt(PaymentHistory::getPrice).sum();
-
-    if (responseTotalPrice == getTotalPrice) {
-      pendingPaymentHistories.forEach(
-          pendingPayment -> {
-            pendingPayment.setPaymentKey(paymentKey);
-            pendingPayment.setPaymentDate(paymentDate);
-            pendingPayment.setOrderId(orderId);
-            pendingPayment.setStatus(status);
-            paymentHistoryRepository.save(pendingPayment);
-            cartItemService.deleteCartItem(userEmail, pendingPayment.getCartItemId());
-          });
-    } else {
-      failPayment(userEmail);
-      throw new DifferentAmountRequestException();
+    public ResponseEntity<String> confirmPayment(
+     String userEmail, SuccessPaymentRequest paymentRequests){
+        ResponseEntity<String> response = TossPay.pay(paymentRequests);
+        if (response.getStatusCodeValue() == 200) {
+            updatePayments(userEmail, response);
+            return ResponseEntity.status(response.getStatusCode()).body("{\"message\": \"결제에 성공했습니다\" }");
+        } else {
+            throw new TossPayResponseException(response);
+        }
     }
-  }
+
+    public void deleteFailPayment(String userEmail) {
+        paymentHistoryRepository.deleteByUserEmailAndStatusIsNull(userEmail);
+    }
+
+    public void addPendingPayments(String userEmail, List<PendingPaymentRequest> paymentRequests) {
+        paymentRequests.forEach(
+         paymentRequest -> {
+             Book book = bookFinder.bookFinder(paymentRequest.getBookId());
+             addPendingPayment(userEmail, book, paymentRequest);
+         });
+    }
+
+    private void addPendingPayment(
+     String userEmail, Book book, PendingPaymentRequest paymentRequest) {
+        PaymentHistory paymentHistory =
+         PaymentHistory.builder()
+          .userEmail(userEmail)
+          .title(book.getTitle())
+          .author(book.getAuthor())
+          .category(book.getCategory())
+          .img(book.getImg())
+          .publisher(book.getPublisher())
+          .amount(paymentRequest.getAmount())
+          .price(paymentRequest.getAmount() * book.getPrice())
+          .cartItemId(paymentRequest.getCartItemId())
+          .build();
+        paymentHistoryRepository.save(paymentHistory);
+    }
+
+    private void updatePayments(String userEmail, ResponseEntity<String> response) {
+        JSONObject jsonObject = new JSONObject(response.getBody());
+        String paymentKey = jsonObject.getString("paymentKey");
+        String orderId = jsonObject.getString("orderId");
+        String paymentDate = jsonObject.getString("approvedAt");
+        String status = jsonObject.getString("status");
+
+        List<PaymentHistory> pendingPaymentHistories =
+         paymentHistoryRepository.findByUserEmailAndStatusIsNull(userEmail);
+
+        int responseTotalPrice = jsonObject.getInt("totalAmount");
+        int getTotalPrice = pendingPaymentHistories.stream().mapToInt(PaymentHistory::getPrice).sum();
+
+        if (responseTotalPrice == getTotalPrice) {
+            pendingPaymentHistories.forEach(
+             pendingPayment -> {
+                 pendingPayment.setPaymentKey(paymentKey);
+                 pendingPayment.setPaymentDate(paymentDate);
+                 pendingPayment.setOrderId(orderId);
+                 pendingPayment.setStatus(status);
+                 paymentHistoryRepository.save(pendingPayment);
+                 cartItemService.deleteCartItem(userEmail, pendingPayment.getCartItemId());
+             });
+        } else {
+            throw new DifferentAmountRequestException();
+        }
+    }
 }

--- a/src/main/java/com/reactlibraryproject/springbootlibrary/Utils/TossPay.java
+++ b/src/main/java/com/reactlibraryproject/springbootlibrary/Utils/TossPay.java
@@ -24,20 +24,23 @@ public class TossPay {
         TossPay.tossSecretKey = secretKey;
     }
 
-    public static ResponseEntity<String> pay(SuccessPaymentRequest paymentRequests) throws IOException, InterruptedException {
+    public static ResponseEntity<String> pay(SuccessPaymentRequest paymentRequests) {
         String requestBody = createPaymentConfirmRequestBody(paymentRequests);
 
         HttpRequest request =
          HttpRequest.newBuilder()
           .uri(URI.create("https://api.tosspayments.com/v1/payments/confirm"))
-          .header("Authorization", "Basic " + tossSecretKey)
+          .header("Authorization", "Basic " + "test")
           .header("Content-Type", "application/json")
           .method("POST", HttpRequest.BodyPublishers.ofString(requestBody))
           .build();
 
-        HttpResponse<String> response =
-         HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
-        
+        HttpResponse<String> response;
+        try {
+            response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
         return ResponseEntity.status(response.statusCode()).body(response.body());
     }
 

--- a/src/main/java/com/reactlibraryproject/springbootlibrary/Utils/TossPay.java
+++ b/src/main/java/com/reactlibraryproject/springbootlibrary/Utils/TossPay.java
@@ -30,7 +30,7 @@ public class TossPay {
         HttpRequest request =
          HttpRequest.newBuilder()
           .uri(URI.create("https://api.tosspayments.com/v1/payments/confirm"))
-          .header("Authorization", "Basic " + "test")
+          .header("Authorization", "Basic " + tossSecretKey)
           .header("Content-Type", "application/json")
           .method("POST", HttpRequest.BodyPublishers.ofString(requestBody))
           .build();


### PR DESCRIPTION
1. `PaymentHistoryController`
- import 를 single class import로 변경함.
- successPayment 의 메소드이름을 confirmPayment로 변경했음. ( successPayment 가 실질적 결제 성공이 아니기 때문에, 승인 API를 호출하고 완전히 결제를 점검하는 과정을 뜻하는 의미로 confirmPayment로 변경함.)
- confirmPayment는 Exception을 throws 하지 않게 수정함.
- failPayment의 메소드 명을 목적을 더 쉽게 파악할 수 있게 deleteFailPayment로 변경하였음.

2.`PaymentService`
- 결제 내역 시 결제에 실패한 내역을 삭제 먼저 하도록 해서 에러를 예방하였음.
- 결제 내역 조회시 최신 결제일을 기준으로 정렬시킴
- 프론트에서 보여주기 위한 key값으로 Pk를 주입시킴.
- 결제일로 그룹핑했으나 유니크 값이 될 수 있는 orderId로 변경함.

3.`TossPay`
- IOException과 InterruptedException을 Toss.pay에서 try-catch로 처리함. 이제 더이상 service에서 throws 하지 않음.

4.`TossPayResponseException`
- 안쓰는 import 삭제