### PR TITLE
Feature/#130 services refactoring

### DIFF
--- a/src/main/java/com/reactlibraryproject/springbootlibrary/Controller/BookController.java
+++ b/src/main/java/com/reactlibraryproject/springbootlibrary/Controller/BookController.java
@@ -1,7 +1,7 @@
 package com.reactlibraryproject.springbootlibrary.Controller;
 
 import com.reactlibraryproject.springbootlibrary.Entity.Book;
-import com.reactlibraryproject.springbootlibrary.ReponseModels.ShelfCurrentLoansResponse;
+import com.reactlibraryproject.springbootlibrary.ReponseModels.CurrentLoansResponse;
 import com.reactlibraryproject.springbootlibrary.Service.BookService;
 import com.reactlibraryproject.springbootlibrary.Utils.ExtractJWT;
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,7 +28,7 @@ public class BookController {
 
     @Operation(summary = "유저의 현재 대여중인 책 목록")
     @GetMapping("/secure/currentloans")
-    public List<ShelfCurrentLoansResponse> currentLoans(@RequestHeader(value = "Authorization") String token) throws Exception {
+    public List<CurrentLoansResponse> currentLoans(@RequestHeader(value = "Authorization") String token) throws Exception {
         String userEmail = ExtractJWT.payloadJWTExtraction(token, "\"sub\"");
         return bookService.currentLoans(userEmail);
     }
@@ -49,9 +49,9 @@ public class BookController {
 
     @Operation(summary = "책 대여")
     @PutMapping("/secure/checkout")
-    public Book checkoutBook(@RequestHeader(value = "Authorization") String token, @RequestParam Long bookId) throws Exception {
+    public Book checkoutBook(@RequestHeader(value = "Authorization") String token, @RequestParam Long bookId, @RequestParam int amount){
         String userEmail = ExtractJWT.payloadJWTExtraction(token, "\"sub\"");
-        return bookService.checkoutBook(userEmail, bookId);
+        return bookService.checkoutBook(userEmail, bookId, amount);
     }
 
     @Operation(summary = "책 반납")

--- a/src/main/java/com/reactlibraryproject/springbootlibrary/Controller/PaymentController.java
+++ b/src/main/java/com/reactlibraryproject/springbootlibrary/Controller/PaymentController.java
@@ -26,7 +26,7 @@ import java.util.Map;
 @AllArgsConstructor
 @RequestMapping("/api/payment-histories")
 @Tag(name = "결제", description = "결제 API")
-public class PaymentHistoryController {
+public class PaymentController {
 
     private PaymentService paymentService;
 
@@ -47,18 +47,18 @@ public class PaymentHistoryController {
         paymentService.addPendingPayments(userEmail, paymentRequests);
     }
 
-    @Operation(summary = "결제 실패시 DB에서 삭제")
+    @Operation(summary = "결제 실패 내역 삭제")
     @DeleteMapping("/secure/delete/fail")
     public void deleteFailPayment(@RequestHeader(value = "Authorization") String token) {
         String userEmail = ExtractJWT.payloadJWTExtraction(token, "\"sub\"");
-        paymentService.deleteFailPayment(userEmail);
+        paymentService.deleteFailedPayments(userEmail);
     }
 
-    @Operation(summary = "결제 승인 API 호출", description = "API 호출 후 결제 내역 업데이트")
+    @Operation(summary = "결제 승인 API 호출", description = "API 승인 후 결제 내역 업데이트")
     @PostMapping("/secure/confirm")
     public ResponseEntity<String> confirmPayment(
      @RequestHeader(value = "Authorization") String token,
-     @RequestBody SuccessPaymentRequest paymentRequests){
+     @RequestBody SuccessPaymentRequest paymentRequests) {
         String userEmail = ExtractJWT.payloadJWTExtraction(token, "\"sub\"");
         return paymentService.confirmPayment(userEmail, paymentRequests);
     }

--- a/src/main/java/com/reactlibraryproject/springbootlibrary/CustomExceptions/InsufficientCoinsException.java
+++ b/src/main/java/com/reactlibraryproject/springbootlibrary/CustomExceptions/InsufficientCoinsException.java
@@ -1,0 +1,7 @@
+package com.reactlibraryproject.springbootlibrary.CustomExceptions;
+
+public class InsufficientCoinsException extends RuntimeException{
+    public InsufficientCoinsException() {
+        super("코인이 부족합니다.");
+    }
+}

--- a/src/main/java/com/reactlibraryproject/springbootlibrary/ReponseModels/CurrentLoansResponse.java
+++ b/src/main/java/com/reactlibraryproject/springbootlibrary/ReponseModels/CurrentLoansResponse.java
@@ -6,7 +6,7 @@ import lombok.Data;
 
 @Data
 @AllArgsConstructor
-public class ShelfCurrentLoansResponse {
+public class CurrentLoansResponse {
     private Book book;
     private int daysLeft;
 }

--- a/src/main/java/com/reactlibraryproject/springbootlibrary/Service/BookService.java
+++ b/src/main/java/com/reactlibraryproject/springbootlibrary/Service/BookService.java
@@ -1,12 +1,15 @@
 package com.reactlibraryproject.springbootlibrary.Service;
 
+import com.reactlibraryproject.springbootlibrary.CustomExceptions.InsufficientCoinsException;
 import com.reactlibraryproject.springbootlibrary.DAO.BookRepository;
 import com.reactlibraryproject.springbootlibrary.DAO.CheckoutRepository;
 import com.reactlibraryproject.springbootlibrary.DAO.CheckoutHistoryRepository;
+import com.reactlibraryproject.springbootlibrary.DAO.CoinRepository;
 import com.reactlibraryproject.springbootlibrary.Entity.Book;
 import com.reactlibraryproject.springbootlibrary.Entity.Checkout;
 import com.reactlibraryproject.springbootlibrary.Entity.CheckoutHistory;
-import com.reactlibraryproject.springbootlibrary.ReponseModels.ShelfCurrentLoansResponse;
+import com.reactlibraryproject.springbootlibrary.Entity.Coin;
+import com.reactlibraryproject.springbootlibrary.ReponseModels.CurrentLoansResponse;
 import com.reactlibraryproject.springbootlibrary.Utils.BookFinder;
 import com.reactlibraryproject.springbootlibrary.Utils.ValidateCheckout;
 import lombok.AllArgsConstructor;
@@ -27,129 +30,141 @@ import java.util.stream.Collectors;
 @Transactional
 public class BookService {
 
-  private BookRepository bookRepository;
+    private BookRepository bookRepository;
 
-  private CheckoutRepository checkoutRepository;
+    private CheckoutRepository checkoutRepository;
 
-  private CheckoutHistoryRepository checkoutHistoryRepository;
+    private CheckoutHistoryRepository checkoutHistoryRepository;
 
-  private BookFinder bookFinder;
-  private ValidateCheckout validateCheckout;
+    private CoinService coinService;
 
-  public Book checkoutBook(String userEmail, Long bookId) {
-    // Exception
-    Book book = bookFinder.bookFinder(bookId);
-    validateCheckout.validate(book, userEmail, bookId);
+    private BookFinder bookFinder;
+    private ValidateCheckout validateCheckout;
+    private final CoinRepository coinRepository;
 
-    // Function
-    book.setCopiesAvailable(book.getCopiesAvailable() - 1);
-    bookRepository.save(book);
-    createCheckout(userEmail, bookId);
+    public Book checkoutBook(String userEmail, Long bookId, int coinsToUse) {
+        // Exception
+        Book book = bookFinder.bookFinder(bookId);
 
-    return book;
-  }
+        Coin coin = coinRepository.findByUserEmail(userEmail);
+        if (coin.getAmount() < coinsToUse) {
+            throw new InsufficientCoinsException();
+        }
 
-  private void createCheckout(String userEmail, Long bookId) {
-    Checkout checkout =
-        Checkout.builder()
-            .userEmail(userEmail)
-            .checkoutDate(LocalDate.now().toString())
-            .returnedDate(LocalDate.now().plusDays(7).toString())
-            .bookId(bookId)
-            .build();
+        validateCheckout.validate(book, userEmail, bookId);
 
-    checkoutRepository.save(checkout);
-  }
+        // Function
+        book.setCopiesAvailable(book.getCopiesAvailable() - 1);
+        bookRepository.save(book);
+        createCheckout(userEmail, bookId);
+        LocalDate currentDate = LocalDate.now();
+        coinService.useCoin(userEmail, book.getTitle(), coinsToUse, currentDate.toString());
 
-  public int currentLoansCount(String userEmail) {
-    return checkoutRepository.findBooksByUserEmail(userEmail).size();
-  }
-
-  public List<ShelfCurrentLoansResponse> currentLoans(String userEmail) {
-    List<Checkout> checkoutList = checkoutRepository.findBooksByUserEmail(userEmail);
-    Map<Long, Checkout> checkoutMap = createCheckoutMap(checkoutList);
-    List<Book> books = bookRepository.findBooksByBookIds(new ArrayList<>(checkoutMap.keySet()));
-
-    return generateShelfCurrentLoansResponseList(checkoutMap, books);
-  }
-
-  private Map<Long, Checkout> createCheckoutMap(List<Checkout> checkoutList) {
-    return checkoutList.stream()
-        .collect(Collectors.toMap(Checkout::getBookId, Function.identity()));
-  }
-
-  private List<ShelfCurrentLoansResponse> generateShelfCurrentLoansResponseList(
-      Map<Long, Checkout> checkoutMap, List<Book> books) {
-    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-    LocalDate currentDate = LocalDate.now();
-
-    return books.stream()
-        .filter(book -> checkoutMap.containsKey(book.getId()))
-        .map(book -> generateShelfCurrentLoanResponse(book, checkoutMap, formatter, currentDate))
-        .collect(Collectors.toList());
-  }
-
-  private ShelfCurrentLoansResponse generateShelfCurrentLoanResponse(
-      Book book,
-      Map<Long, Checkout> checkoutMap,
-      DateTimeFormatter formatter,
-      LocalDate currentDate) {
-    Checkout checkout = checkoutMap.get(book.getId());
-    LocalDate returnDate = LocalDate.parse(checkout.getReturnedDate(), formatter);
-    long differenceInDays = ChronoUnit.DAYS.between(currentDate, returnDate);
-
-    return new ShelfCurrentLoansResponse(book, (int) differenceInDays);
-  }
-
-  public boolean checkoutBookByUser(String userEmail, Long bookId) {
-    return validateCheckout.checkoutBookByUser(userEmail, bookId);
-  }
-
-  public void returnBook(String userEmail, Long bookId) {
-    // Exception
-    Book book = bookFinder.bookFinder(bookId);
-    Checkout checkout = validateCheckout.validatedCheckout(userEmail, bookId);
-
-    // Function
-    book.setCopiesAvailable(book.getCopiesAvailable() + 1);
-
-    bookRepository.save(book);
-    checkoutRepository.deleteById(checkout.getId());
-
-    saveCheckoutHistory(checkout, book);
-  }
-
-  private void saveCheckoutHistory(Checkout validateCheckout, Book book) {
-    CheckoutHistory checkoutHistory =
-        CheckoutHistory.builder()
-            .userEmail(validateCheckout.getUserEmail())
-            .checkoutDate(validateCheckout.getCheckoutDate())
-            .returnedDate(LocalDate.now().toString())
-            .title(book.getTitle())
-            .author(book.getAuthor())
-            .description(book.getDescription())
-            .img(book.getImg())
-            .build();
-
-    checkoutHistoryRepository.save(checkoutHistory);
-  }
-
-  public void renewLoan(String userEmail, Long bookId) {
-    // Exception
-    Checkout checkout = validateCheckout.validatedCheckout(userEmail, bookId);
-
-    // Function
-    extendLoan(checkout);
-  }
-
-  private void extendLoan(Checkout checkout) {
-    LocalDate currentDate = LocalDate.now();
-    LocalDate returnDate = LocalDate.parse(checkout.getReturnedDate());
-
-    if (!returnDate.isBefore(currentDate)) {
-      int renewalPeriod = 7;
-      checkout.setReturnedDate(currentDate.plusDays(renewalPeriod).toString());
-      checkoutRepository.save(checkout);
+        return book;
     }
-  }
+
+    private void createCheckout(String userEmail, Long bookId) {
+        Checkout checkout =
+         Checkout.builder()
+          .userEmail(userEmail)
+          .checkoutDate(LocalDate.now().toString())
+          .returnedDate(LocalDate.now().plusDays(7).toString())
+          .bookId(bookId)
+          .build();
+
+        checkoutRepository.save(checkout);
+    }
+
+    public int currentLoansCount(String userEmail) {
+        return checkoutRepository.findBooksByUserEmail(userEmail).size();
+    }
+
+
+    public List<CurrentLoansResponse> currentLoans(String userEmail) {
+        List<Checkout> checkoutList = checkoutRepository.findBooksByUserEmail(userEmail);
+        Map<Long, Checkout> checkoutMap = createCheckoutMap(checkoutList);
+        List<Book> books = bookRepository.findBooksByBookIds(new ArrayList<>(checkoutMap.keySet()));
+        LocalDate currentDate = LocalDate.now();
+
+        return generateShelfCurrentLoansResponseList(checkoutMap, books, currentDate);
+    }
+
+    private Map<Long, Checkout> createCheckoutMap(List<Checkout> checkoutList) {
+        return checkoutList.stream()
+         .collect(Collectors.toMap(Checkout::getBookId, Function.identity()));
+    }
+
+    private List<CurrentLoansResponse> generateShelfCurrentLoansResponseList(
+     Map<Long, Checkout> checkoutMap, List<Book> books, LocalDate currentDate) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+        return books.stream()
+         .filter(book -> checkoutMap.containsKey(book.getId()))
+         .map(book -> generateShelfCurrentLoanResponse(book, checkoutMap, formatter, currentDate))
+         .collect(Collectors.toList());
+    }
+
+    private CurrentLoansResponse generateShelfCurrentLoanResponse(
+     Book book,
+     Map<Long, Checkout> checkoutMap,
+     DateTimeFormatter formatter,
+     LocalDate currentDate) {
+        Checkout checkout = checkoutMap.get(book.getId());
+        LocalDate returnDate = LocalDate.parse(checkout.getReturnedDate(), formatter);
+        long differenceInDays = ChronoUnit.DAYS.between(currentDate, returnDate);
+
+        return new CurrentLoansResponse(book, (int) differenceInDays);
+    }
+
+    public boolean checkoutBookByUser(String userEmail, Long bookId) {
+        return validateCheckout.checkoutBookByUser(userEmail, bookId);
+    }
+
+    public void returnBook(String userEmail, Long bookId) {
+        // Exception
+        Book book = bookFinder.bookFinder(bookId);
+        Checkout checkout = validateCheckout.validatedCheckout(userEmail, bookId);
+
+        // Function
+        book.setCopiesAvailable(book.getCopiesAvailable() + 1);
+
+        bookRepository.save(book);
+        checkoutRepository.deleteById(checkout.getId());
+
+        saveCheckoutHistory(checkout, book);
+    }
+
+    private void saveCheckoutHistory(Checkout validateCheckout, Book book) {
+        CheckoutHistory checkoutHistory =
+         CheckoutHistory.builder()
+          .userEmail(validateCheckout.getUserEmail())
+          .checkoutDate(validateCheckout.getCheckoutDate())
+          .returnedDate(LocalDate.now().toString())
+          .title(book.getTitle())
+          .author(book.getAuthor())
+          .description(book.getDescription())
+          .img(book.getImg())
+          .build();
+
+        checkoutHistoryRepository.save(checkoutHistory);
+    }
+
+    public void renewLoan(String userEmail, Long bookId) {
+        // Exception
+        Checkout checkout = validateCheckout.validatedCheckout(userEmail, bookId);
+
+        // Function
+        LocalDate currentDate = LocalDate.now();
+        extendLoan(checkout, currentDate);
+    }
+
+    private void extendLoan(Checkout checkout, LocalDate currentDate) {
+        LocalDate returnDate = LocalDate.parse(checkout.getReturnedDate());
+
+        if (!returnDate.isBefore(currentDate)) {
+            int renewalPeriod = 7;
+            checkout.setReturnedDate(currentDate.plusDays(renewalPeriod).toString());
+            checkoutRepository.save(checkout);
+        }
+    }
 }

--- a/src/main/java/com/reactlibraryproject/springbootlibrary/Utils/ValidateCheckout.java
+++ b/src/main/java/com/reactlibraryproject/springbootlibrary/Utils/ValidateCheckout.java
@@ -17,10 +17,8 @@ public class ValidateCheckout {
   public void validate(Book book, String userEmail, Long bookId) {
     if (checkoutBookByUser(userEmail, bookId)) {
       throw new AlreadyCheckedOutException();
-    } else if (checkoutAvailable(book)) {
+    } else if (!checkoutAvailable(book)) {
       throw new CopiesAvailableException();
-    } else {
-      throw new NotCheckedOutException();
     }
   }
 

--- a/src/test/java/com/reactlibraryproject/springbootlibrary/Service/BookServiceTest.java
+++ b/src/test/java/com/reactlibraryproject/springbootlibrary/Service/BookServiceTest.java
@@ -3,10 +3,12 @@ package com.reactlibraryproject.springbootlibrary.Service;
 import com.reactlibraryproject.springbootlibrary.DAO.BookRepository;
 import com.reactlibraryproject.springbootlibrary.DAO.CheckoutHistoryRepository;
 import com.reactlibraryproject.springbootlibrary.DAO.CheckoutRepository;
+import com.reactlibraryproject.springbootlibrary.DAO.CoinRepository;
 import com.reactlibraryproject.springbootlibrary.Entity.Book;
 import com.reactlibraryproject.springbootlibrary.Entity.Checkout;
 import com.reactlibraryproject.springbootlibrary.Entity.CheckoutHistory;
-import com.reactlibraryproject.springbootlibrary.ReponseModels.ShelfCurrentLoansResponse;
+import com.reactlibraryproject.springbootlibrary.Entity.Coin;
+import com.reactlibraryproject.springbootlibrary.ReponseModels.CurrentLoansResponse;
 import com.reactlibraryproject.springbootlibrary.Utils.BookFinder;
 import com.reactlibraryproject.springbootlibrary.Utils.ValidateCheckout;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,7 +22,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,151 +35,177 @@ import static org.mockito.Mockito.*;
 @DisplayName("책 관련 서비스 테스트")
 class BookServiceTest {
 
-  @InjectMocks private BookService bookService;
+    @InjectMocks
+    private BookService bookService;
 
-  public Book testBook;
+    public Book testBook;
 
-  public Checkout checkout;
+    public Checkout checkout;
 
-  public Long bookId;
+    public Long bookId;
 
-  public String userEmail;
-  @Mock private BookFinder bookFinder;
-  @Mock private ValidateCheckout validateCheckout;
+    public String userEmail;
 
-  @Mock private BookRepository bookRepository;
+    public Coin testCoin;
+    @Mock
+    private BookFinder bookFinder;
+    @Mock
+    private ValidateCheckout validateCheckout;
 
-  @Mock private CheckoutRepository checkoutRepository;
+    @Mock
+    private BookRepository bookRepository;
 
-  @Mock private CheckoutHistoryRepository checkoutHistoryRepository;
+    @Mock
+    private CheckoutRepository checkoutRepository;
 
-  @BeforeEach
-  void setUp() {
-    bookId = 1L;
-    userEmail = "user@email.com";
-    testBook =
-        Book.builder()
-            .id(1L)
-            .title("Title")
-            .author("Author")
-            .description("Description")
-            .copies(1)
-            .copiesAvailable(1)
-            .category("Category")
-            .img("Image")
-            .publisher("Publisher")
-            .price(10000)
-            .coin(0)
-            .publicationDate("2023-03-18")
-            .build();
-    checkout =
-        Checkout.builder()
-            .id(1L)
-            .userEmail(userEmail)
-            .checkoutDate(LocalDate.now().toString())
-            .returnedDate(LocalDate.now().plusDays(7).toString())
-            .bookId(bookId)
-            .build();
-  }
+    @Mock
+    private CheckoutHistoryRepository checkoutHistoryRepository;
 
-  @Test
-  @DisplayName("책 대여 테스트")
-  void checkoutBook() {
-    // Given
-    given(bookFinder.bookFinder(bookId)).willReturn(testBook);
-    doNothing()
-        .when(validateCheckout)
-        .validate(any(Book.class), any(String.class), any(Long.class));
+    @Mock
+    private CoinRepository coinRepository;
 
-    // When
-    Book checkedOutBook = bookService.checkoutBook(userEmail, bookId);
+    @Mock
+    private CoinService coinService;
 
-    // Then
-    assertNotNull(checkedOutBook);
-  }
+    @BeforeEach
+    void setUp() {
+        bookId = 1L;
+        userEmail = "user@email.com";
+        testBook =
+         Book.builder()
+          .id(1L)
+          .title("Title")
+          .author("Author")
+          .description("Description")
+          .copies(1)
+          .copiesAvailable(1)
+          .category("Category")
+          .img("Image")
+          .publisher("Publisher")
+          .price(10000)
+          .coin(0)
+          .publicationDate("2023-03-18")
+          .build();
+        checkout =
+         Checkout.builder()
+          .id(1L)
+          .userEmail(userEmail)
+          .checkoutDate(LocalDate.now().toString())
+          .returnedDate(LocalDate.now().plusDays(7).toString())
+          .bookId(bookId)
+          .build();
+        testCoin = Coin.builder()
+         .userEmail(userEmail)
+         .amount(3)
+         .build();
+    }
 
-  @Test
-  @DisplayName("책 대여 여부 테스트")
-  void checkoutBookByUser() {
-    // Given
+    @Test
+    @DisplayName("책 대여 테스트")
+    void checkoutBook() {
+        // Given
+        given(bookFinder.bookFinder(bookId)).willReturn(testBook);
+        given(coinRepository.findByUserEmail(userEmail)).willReturn(testCoin);
+        doNothing()
+         .when(validateCheckout)
+         .validate(any(Book.class), any(String.class), any(Long.class));
+        doNothing()
+         .when(coinService)
+         .useCoin(any(String.class), any(String.class), any(Integer.class), any(String.class));
+        int coinsToUse = 3;
 
-    // When
-    boolean validate = bookService.checkoutBookByUser(userEmail, bookId);
+        // When
+        Book checkedOutBook = bookService.checkoutBook(userEmail, bookId, coinsToUse);
 
-    // Then
-    assertFalse(validate);
-  }
+        // Then
+        assertNotNull(checkedOutBook);
+        assertEquals(testBook.getId(), checkedOutBook.getId());
+        assertEquals(testBook.getTitle(), checkedOutBook.getTitle());
+    }
 
-  @Test
-  @DisplayName("현재 대여중인 책의 수 테스트")
-  void currentLoansCount() {
-    // Given
-    given(checkoutRepository.findBooksByUserEmail(userEmail))
-        .willReturn(Collections.singletonList(checkout));
 
-    // When
-    int loansCount = bookService.currentLoansCount(userEmail);
+    @Test
+    @DisplayName("책 대여 여부 테스트")
+    void checkoutBookByUser() {
+        // Given
 
-    // Then
-    assertEquals(1, loansCount);
-  }
+        // When
+        boolean validate = bookService.checkoutBookByUser(userEmail, bookId);
 
-  @Test
-  @DisplayName("현재 대여중인 책 목록 테스트")
-  void currentLoans() {
-    // Given
-    List<Checkout> checkoutList = Collections.singletonList(checkout);
-    given(checkoutRepository.findBooksByUserEmail(userEmail)).willReturn(checkoutList);
-    given(bookRepository.findBooksByBookIds(Collections.singletonList(bookId)))
-        .willReturn(Collections.singletonList(testBook));
+        // Then
+        assertFalse(validate);
+    }
 
-    // When
-    List<ShelfCurrentLoansResponse> shelfCurrentLoansResponses =
-        bookService.currentLoans(userEmail);
+    @Test
+    @DisplayName("현재 대여중인 책의 수 테스트")
+    void currentLoansCount() {
+        // Given
+        given(checkoutRepository.findBooksByUserEmail(userEmail))
+         .willReturn(Collections.singletonList(checkout));
 
-    // Then
-    assertEquals(1, shelfCurrentLoansResponses.size());
-    List<Book> returnedBooks =
-        shelfCurrentLoansResponses.stream()
-            .map(ShelfCurrentLoansResponse::getBook)
-            .collect(Collectors.toList());
-    assertEquals(Collections.singletonList(testBook), returnedBooks);
-    List<Integer> returnedDaysLeft =
-        shelfCurrentLoansResponses.stream()
-            .map(ShelfCurrentLoansResponse::getDaysLeft)
-            .collect(Collectors.toList());
-    assertEquals(Collections.singletonList(7), returnedDaysLeft);
-  }
+        // When
+        int loansCount = bookService.currentLoansCount(userEmail);
 
-  @Test
-  @DisplayName("책 반납 테스트")
-  void returnBook() {
-    // Given
-    given(bookFinder.bookFinder(bookId)).willReturn(testBook);
-    given(validateCheckout.validatedCheckout(userEmail, bookId)).willReturn(checkout);
+        // Then
+        assertEquals(1, loansCount);
+    }
 
-    // When
-    bookService.returnBook(userEmail, bookId);
+    @Test
+    @DisplayName("현재 대여중인 책 목록 테스트")
+    void currentLoans() {
+        // Given
+        List<Checkout> checkoutList = Collections.singletonList(checkout);
+        given(checkoutRepository.findBooksByUserEmail(userEmail)).willReturn(checkoutList);
+        given(bookRepository.findBooksByBookIds(Collections.singletonList(bookId)))
+         .willReturn(Collections.singletonList(testBook));
 
-    // Then
-    assertEquals(2, testBook.getCopiesAvailable());
-    verify(bookRepository).save(testBook);
-    verify(checkoutRepository).deleteById(checkout.getId());
-    verify(checkoutHistoryRepository).save(any(CheckoutHistory.class));
-  }
+        // When
+        List<CurrentLoansResponse> currentLoansRespons =
+         bookService.currentLoans(userEmail);
 
-  @Test
-  @DisplayName("대출 기간 초기화 테스트")
-  void renewLoan() {
-    // Given
-    LocalDate currentDate = LocalDate.now();
-    given(validateCheckout.validatedCheckout(userEmail, bookId)).willReturn(checkout);
+        // Then
+        assertEquals(1, currentLoansRespons.size());
+        List<Book> returnedBooks =
+         currentLoansRespons.stream()
+          .map(CurrentLoansResponse::getBook)
+          .collect(Collectors.toList());
+        assertEquals(Collections.singletonList(testBook), returnedBooks);
+        List<Integer> returnedDaysLeft =
+         currentLoansRespons.stream()
+          .map(CurrentLoansResponse::getDaysLeft)
+          .collect(Collectors.toList());
+        assertEquals(Collections.singletonList(7), returnedDaysLeft);
+    }
 
-    // When
-    bookService.renewLoan(userEmail, bookId);
+    @Test
+    @DisplayName("책 반납 테스트")
+    void returnBook() {
+        // Given
+        given(bookFinder.bookFinder(bookId)).willReturn(testBook);
+        given(validateCheckout.validatedCheckout(userEmail, bookId)).willReturn(checkout);
 
-    // Then
-    assertEquals(currentDate.plusDays(7).toString(), checkout.getReturnedDate());
-    verify(checkoutRepository).save(checkout);
-  }
+        // When
+        bookService.returnBook(userEmail, bookId);
+
+        // Then
+        assertEquals(2, testBook.getCopiesAvailable());
+        verify(bookRepository).save(testBook);
+        verify(checkoutRepository).deleteById(checkout.getId());
+        verify(checkoutHistoryRepository).save(any(CheckoutHistory.class));
+    }
+
+    @Test
+    @DisplayName("대출 기간 초기화 테스트")
+    void renewLoan() {
+        // Given
+        LocalDate currentDate = LocalDate.now();
+        given(validateCheckout.validatedCheckout(userEmail, bookId)).willReturn(checkout);
+
+        // When
+        bookService.renewLoan(userEmail, bookId);
+
+        // Then
+        assertEquals(currentDate.plusDays(7).toString(), checkout.getReturnedDate());
+        verify(checkoutRepository).save(checkout);
+    }
 }

--- a/src/test/java/com/reactlibraryproject/springbootlibrary/Service/CoinServiceTest.java
+++ b/src/test/java/com/reactlibraryproject/springbootlibrary/Service/CoinServiceTest.java
@@ -1,7 +1,10 @@
 package com.reactlibraryproject.springbootlibrary.Service;
 
+import com.reactlibraryproject.springbootlibrary.DAO.CoinChargingHistoryRepository;
 import com.reactlibraryproject.springbootlibrary.DAO.CoinRepository;
 import com.reactlibraryproject.springbootlibrary.Entity.Coin;
+import com.reactlibraryproject.springbootlibrary.Entity.CoinChargingHistory;
+import com.reactlibraryproject.springbootlibrary.ReponseModels.CoinChargingHistoryResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,6 +14,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+
+import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -25,8 +31,13 @@ class CoinServiceTest {
 
     public Coin coin;
 
+    public List<CoinChargingHistory> coinHistories;
+
     @Mock
     private CoinRepository coinRepository;
+
+    @Mock
+    private CoinChargingHistoryRepository coinChargingHistoryRepository;
 
     @BeforeEach
     void setUp() {
@@ -35,6 +46,16 @@ class CoinServiceTest {
          .userEmail("user@email.com")
          .amount(100)
          .build();
+        CoinChargingHistory coinChargingHistory = CoinChargingHistory.builder()
+         .price(10000)
+         .userEmail("user@email.com")
+         .amount(100)
+         .paymentKey("paymentKey")
+         .paymentDate("2023-03-24")
+         .orderId("orderId")
+         .status("DONE")
+         .build();
+        coinHistories = Collections.singletonList(coinChargingHistory);
     }
 
     @Test
@@ -50,17 +71,18 @@ class CoinServiceTest {
         assertEquals(100, userCoins);
     }
 
+
     @Test
-    @DisplayName("코인으로 결제 테스트")
-    void useCoin() throws Exception {
-        // Given
-        when(coinRepository.findByUserEmail(anyString())).thenReturn(coin);
-        int coinsToUse = 30;
+    @DisplayName("코인 충전 내역 테스트")
+    void coinHistories() {
+        //Given
+        when(coinChargingHistoryRepository.findByUserEmail(anyString())).thenReturn(coinHistories);
 
-        // When
-        coinService.useCoin(coin.getUserEmail(), coinsToUse);
+        //When
+        List<CoinChargingHistoryResponse> historyResponseList = coinService.getCoinChargingHistory(anyString());
 
-        // Then
-        assertEquals(coin.getAmount(), 70);
+        //Then
+        assertEquals(1, historyResponseList.size());
     }
+
 }

--- a/src/test/java/com/reactlibraryproject/springbootlibrary/Service/PaymentServiceTest.java
+++ b/src/test/java/com/reactlibraryproject/springbootlibrary/Service/PaymentServiceTest.java
@@ -90,7 +90,7 @@ class PaymentServiceTest {
     String userEmail = "user@email.com";
 
     // When
-    paymentService.failPayment(userEmail);
+    paymentService.deleteFailedPayments(userEmail);
 
     // Then
     verify(paymentHistoryRepository, times(1)).deleteByUserEmailAndStatusIsNull(userEmail);


### PR DESCRIPTION
책 대여 API 호출시 코인 사용 로직 추가함.
@RequestParam의 코인 사용량 추가

ShelfCurrentLoansResponse -> CurrentLoansResponse로 변경함.

메소드 한번 더 분리하고, 메소드마다 주석을 달아 메소드 목적을 파악하게끔 명시함.

1.`InsufficientCoinsException`
코인이 부족한 경우에 생기는 사용자 정의 예외처리

2. `ValidateCheckout`
불필요한 예외처리 제거함.

3. `TestCode`
로직 변경에 따른 테스트 코드 일부 변경.